### PR TITLE
Fix colors when guioptions has the 'c' flag.

### DIFF
--- a/colors/solarized-dark.penta
+++ b/colors/solarized-dark.penta
@@ -87,6 +87,8 @@ hi MoreMsg -a color: inherit !important; background-color: inherit !important;
 hi -l=s_green Filter -a
 hi -l=s_base0 InfoMsg
 hi -l=s_base01 ModeMsg
+hi -l=s_base0,s_base03_back CmdCmdLine
+hi -l=s_base03,s_magenta_back CmdErrorMsg
 
 " Hints                                                             {{{1
 " ----------------------------------------------------------------------

--- a/colors/solarized-light.penta
+++ b/colors/solarized-light.penta
@@ -88,6 +88,8 @@ hi MoreMsg -a color: inherit !important; background-color: inherit !important;
 hi -l=s_green Filter -a
 hi -l=s_base00 InfoMsg
 hi -l=s_base01 ModeMsg
+hi -l=s_base00,s_base3_back CmdCmdLine
+hi -l=s_base3,s_magenta_back CmdErrorMsg
 
 " Hints                                                             {{{1
 " ----------------------------------------------------------------------


### PR DESCRIPTION
When guioptions has the 'c' flag the command line is always visible, but
currently without these changes the color scheme is not always visible.
Any other situations in which the color scheme is not visible have not
yet been found, (but my usage patterns may prevent them from being found
of course).
